### PR TITLE
Led Mock

### DIFF
--- a/src/devices/led_mock.py
+++ b/src/devices/led_mock.py
@@ -1,0 +1,24 @@
+"""
+Mock LED device for the Tank Controller.
+"""
+
+
+class LED:
+    """Mock LED that tracks an ON/OFF state."""
+
+    def __init__(self):
+        """Initialize the LED as off."""
+        self.is_on = False
+
+    def on(self):
+        """Turn the LED on."""
+        self.is_on = True
+
+    def off(self):
+        """Turn the LED off."""
+        self.is_on = False
+
+    def toggle(self):
+        """Toggle the LED between on and off."""
+        self.is_on = not self.is_on
+        

--- a/src/devices/library.py
+++ b/src/devices/library.py
@@ -21,6 +21,7 @@ if mock_config.MOCK_ENABLED:
     from src.devices.max31865_mock import MAX31865
     from src.devices.serial_mock import Serial
     from src.devices.spi_mock import SPI
+    from src.devices.led_mock import LED
 else:
     import adafruit_ads1x15.ads1115 as ADS
     import board

--- a/src/gui.py
+++ b/src/gui.py
@@ -34,7 +34,7 @@ class GUI:
 
         # Initialize the GUI Frame
         self.root = tk.Tk()
-        self.root.state("zoomed")
+        self.root.geometry("560x200")
         self.root.title("Tank Controller")
         self.root.configure(background="black")
 

--- a/src/gui.py
+++ b/src/gui.py
@@ -34,15 +34,31 @@ class GUI:
 
         # Initialize the GUI Frame
         self.root = tk.Tk()
-        self.root.geometry("280x200")
+        self.root.state("zoomed")
         self.root.title("Tank Controller")
         self.root.configure(background="black")
+
+        # Split window into left and right sections
         self.root.columnconfigure(0, weight=1)
+        self.root.columnconfigure(1, weight=1)
         self.root.rowconfigure(0, weight=1)
 
+        # ---------------------------------------------------------
+        # LEFT SIDE - LCD AND KEYPAD
+        # ---------------------------------------------------------
+
+        left_frame = tk.Frame(self.root, bg="lightgray")
+        left_frame.grid(row=0, column=0, sticky=STICKY)
+
+        left_frame.columnconfigure(0, weight=1)
+        left_frame.rowconfigure(0, weight=1)
+        left_frame.rowconfigure(1, weight=1)
+
         # Initialize the Labels
-        label_frame = tk.Frame(self.root)
+        label_frame = tk.Frame(left_frame)
         label_frame.config(bg=BG)
+
+        label_frame.columnconfigure(0, weight=1)
         label_frame.rowconfigure(0, weight=1)
         label_frame.rowconfigure(1, weight=1)
         label_frame.rowconfigure(2, weight=1)
@@ -95,7 +111,7 @@ class GUI:
         label_frame.grid(row=0, column=0, sticky=STICKY)
 
         # Initialize the Buttons
-        buttonframe = tk.Frame(self.root)
+        buttonframe = tk.Frame(left_frame)
         buttonframe.columnconfigure(0, weight=1)
         buttonframe.columnconfigure(1, weight=1)
         buttonframe.columnconfigure(2, weight=1)
@@ -215,7 +231,50 @@ class GUI:
 
         buttonframe.grid(row=1, column=0, sticky=STICKY)
 
-        self.thread = threading.Thread(target=self.update_lcd, daemon=True)
+        # ---------------------------------------------------------
+        # RIGHT SIDE - BOARD LED
+        # ---------------------------------------------------------
+
+        right_frame = tk.Frame(self.root, bg="darkgray")
+        right_frame.grid(row=0, column=1, sticky=STICKY)
+
+        right_frame.columnconfigure(0, weight=1)
+        right_frame.columnconfigure(1, weight=1)
+        right_frame.rowconfigure(0, weight=1)
+
+        self.led_canvas = tk.Canvas(
+            right_frame,
+            width=80,
+            height=80,
+            bg="darkgray",
+            highlightthickness=0,
+        )
+        self.led_canvas.grid(row=0, column=0, padx=30, sticky=tk.E)
+
+        self.led_circle = self.led_canvas.create_oval(
+            5,
+            5,
+            50,
+            50,
+            fill="red",
+            outline="black",
+            width=3,
+        )
+
+        self.led_label = tk.Label(
+            right_frame,
+            text="Board LED",
+            font=("Arial",12),
+            bg="darkgray",
+            fg="black",
+        )
+        self.led_label.grid(row=0, column=1, padx=20, sticky=tk.W)
+
+        # Start GUI update thread
+        self.thread = threading.Thread(
+            target=self.update_gui,
+            daemon=True,
+        )
         self.thread.start()
 
         self.root.mainloop()
@@ -226,12 +285,13 @@ class GUI:
         """
         self.titrator.keypad.set_key(key)
 
-    def update_lcd(self):
+    def update_gui(self):
         """
-        The function to update the GUI LCD
+        The function to update the GUI LCD and LED
         """
         while True:
             time.sleep(0.001)
+
             self.line_1.config(
                 text=self.titrator.lcd.get_line(1),
                 anchor=self.titrator.lcd.get_style(1),
@@ -248,3 +308,14 @@ class GUI:
                 text=self.titrator.lcd.get_line(4),
                 anchor=self.titrator.lcd.get_style(4),
             )
+
+            if self.titrator.led.is_on:
+                self.led_canvas.itemconfig(
+                    self.led_circle,
+                    fill="yellow",
+                )
+            else:
+                self.led_canvas.itemconfig(
+                    self.led_circle,
+                    fill="black",
+                )

--- a/src/titrator.py
+++ b/src/titrator.py
@@ -14,6 +14,7 @@ from src.devices.library import (
     SyringePump,
     TemperatureControl,
     TemperatureProbe,
+    LED,
 )
 from src.devices.ph_control import PHControl
 from src.devices.ph_probe_mock import PHProbe
@@ -63,6 +64,9 @@ class Titrator:
 
         # Initialize LCD
         self.lcd = LiquidCrystal()
+
+        # Initialize LED
+        self.led = LED()
 
         # Initialize Keypad
         self.keypad = Keypad()

--- a/src/ui_state/main_menu.py
+++ b/src/ui_state/main_menu.py
@@ -9,6 +9,7 @@ from src.devices.ph_calibration_warning import PHCalibrationWarning
 from src.ui_state.set_menu.set_chill_or_heat import SetChillOrHeat
 from src.ui_state.set_menu.set_google_mins import SetGoogleSheetInterval
 from src.ui_state.set_menu.set_kd import SetKD
+from src.ui_state.set_menu.set_led import SetLED
 from src.ui_state.set_menu.set_ki import SetKI
 from src.ui_state.set_menu.set_kp import SetKP
 from src.ui_state.set_menu.set_ph_calibration import PHCalibration
@@ -77,6 +78,7 @@ class MainMenu(UIState):
             "Set chill/heat",
             "Set Google mins",
             "Set KD",
+            "Set LED",
             "Set KI",
             "Set KP",
             "Set pH target",
@@ -114,6 +116,7 @@ class MainMenu(UIState):
             SetChillOrHeat,  # Set chill/heat
             SetGoogleSheetInterval,  # Set Google mins
             SetKD,  # Set KD
+            SetLED,  # Set LED
             SetKI,  # Set KI
             SetKP,  # Set KP
             SetPHTarget,  # Set pH target

--- a/src/ui_state/set_menu/set_led.py
+++ b/src/ui_state/set_menu/set_led.py
@@ -1,0 +1,52 @@
+"""
+The file to hold the Set LED class
+"""
+
+from src.devices.library import Keypad
+from src.ui_state.ui_state import UIState
+
+
+class SetLED(UIState):
+    """
+    This is a class for the SetLED state of the Tank Controller
+    """
+
+    def __init__(self, titrator, previous_state=None):
+        super().__init__(titrator)
+        self.previous_state = previous_state
+
+    def loop(self):
+        """
+        The main loop for the SetLED state
+        """
+        self.titrator.lcd.print("LED 1:on; 9:off", line=1)
+
+        if self.titrator.led.is_on:
+            self.titrator.lcd.print("Currently on", line=2)
+        else:
+            self.titrator.lcd.print("Currently off", line=2)
+
+    def handle_key(self, key):
+        """
+        Handle key presses to control the LED.
+        """
+        if key == Keypad.KEY_1:
+            self.titrator.led.on()
+            self.titrator.lcd.print("LED on", line=2)
+            self.return_to_main_menu(ms_delay=3000)
+
+        if key == Keypad.KEY_9:
+            self.titrator.led.off()
+            self.titrator.lcd.print("LED off", line=2)
+            self.return_to_main_menu(ms_delay=3000)
+
+        if key == Keypad.KEY_A:
+            if self.titrator.led.is_on:
+                self.titrator.lcd.print("LED on", line=2)
+            else:
+                self.titrator.lcd.print("LED off", line=2)
+            self.return_to_main_menu(ms_delay=3000)
+
+        if key == Keypad.KEY_D:
+            self._set_next_state(self.previous_state, True)
+            

--- a/tests/devices/led_mock_test.py
+++ b/tests/devices/led_mock_test.py
@@ -1,0 +1,14 @@
+from src.devices.library import LED
+
+led = LED()
+
+print(led.is_on)  # False
+
+led.on()
+print(led.is_on)  # True
+
+led.off()
+print(led.is_on)  # False
+
+led.toggle()
+print(led.is_on)  # True

--- a/tests/devices/led_mock_test.py
+++ b/tests/devices/led_mock_test.py
@@ -1,14 +1,50 @@
-from src.devices.library import LED
+"""
+The file to test the Mock LED class.
+"""
 
-led = LED()
+from src.devices.led_mock import LED
 
-print(led.is_on)  # False
 
-led.on()
-print(led.is_on)  # True
+def test_led_starts_off():
+    """
+    LED should be off when initialized.
+    """
+    led = LED()
 
-led.off()
-print(led.is_on)  # False
+    assert led.is_on is False
 
-led.toggle()
-print(led.is_on)  # True
+
+def test_led_turns_on():
+    """
+    LED should turn on when on() is called.
+    """
+    led = LED()
+
+    led.on()
+
+    assert led.is_on is True
+
+
+def test_led_turns_off():
+    """
+    LED should turn off when off() is called.
+    """
+    led = LED()
+    led.on()
+
+    led.off()
+
+    assert led.is_on is False
+
+
+def test_led_toggle():
+    """
+    LED should switch between on and off when toggle() is called.
+    """
+    led = LED()
+
+    led.toggle()
+    assert led.is_on is True
+
+    led.toggle()
+    assert led.is_on is False

--- a/tests/ui_state/set_menu/set_led_test.py
+++ b/tests/ui_state/set_menu/set_led_test.py
@@ -1,0 +1,29 @@
+"""
+The file to test the SetLED class
+"""
+
+from src.devices.library import Keypad
+from src.titrator import Titrator
+from src.ui_state.set_menu.set_led import SetLED
+
+
+def test_led_on():
+    """Test turning the LED on."""
+    titrator = Titrator()
+    state = SetLED(titrator)
+
+    state.handle_key(Keypad.KEY_1)
+
+    assert titrator.led.is_on is True
+
+
+def test_led_off():
+    """Test turning the LED off."""
+    titrator = Titrator()
+    state = SetLED(titrator)
+
+    titrator.led.on()
+    state.handle_key(Keypad.KEY_9)
+
+    assert titrator.led.is_on is False
+    


### PR DESCRIPTION
- Added mock LED backend integration. Created the LED mock device with ON/OFF/toggle functionality, connected it through library.py and Titrator, added the SetLED UI state for keypad control, and added Set LED to the main menu. This allows the mock LED to be controlled through the existing Tank Controller menu system.

- Added tests for the mock LED, Titrator LED integration, and SetLED keypad controls.

- Added the mock LED visualization to the GUI with a circular indicator that changes between black (OFF) and yellow (ON).